### PR TITLE
fix: 모바일 화면에서 홈 화면 Team Grid 레이아웃이 뭉개지는 현상

### DIFF
--- a/src/components/home/TeamGrid.tsx
+++ b/src/components/home/TeamGrid.tsx
@@ -25,7 +25,7 @@ export default function TeamGrid() {
       <h2 className="text-[32px] font-semibold text-text-primary mb-6 pb-2 border-b-2 border-stanford-red">
         Team
       </h2>
-      <div className="grid grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {teamMembers.map((member) => (
           <a
             key={member.name}


### PR DESCRIPTION
<img width="441" height="431" alt="Screenshot 2026-01-20 at 10 33 45 PM" src="https://github.com/user-attachments/assets/72d90451-ab44-49f0-9283-f7bcefafa7cf" />

안녕하세요~ 좋은 자료 공유주셔서 감사합니다.

링크드인에서 찾게되어 모바일 화면으로 접속했는데 Team 섹션의 레이아웃이 모바일 버전에서 뭉개집니다. 번역가 분들의 레이아웃과 같이 기본 `col-1 md:col-3`를 채택하는게 어떤가 해서 PR 올립니다.